### PR TITLE
Update the version of WifiManager for the PlatformIO example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,7 +107,7 @@ pio project init --board esp32dev
 ```ini
 lib_deps =
     sqfmi/Watchy @ 1.4.1 ; Pinned version to ensure we don't pull broken code
-    https://github.com/tzapu/WiFiManager.git#2.0.3-alpha ; Pinned for the same reason
+    https://github.com/tzapu/WiFiManager.git#v2.0.11-beta ; Pinned for the same reason
 lib_ldf_mode = deep+
 board_build.partitions = min_spiffs.csv
 ```


### PR DESCRIPTION
I got compile errors when following https://watchy.sqfmi.com/docs/getting-started/#simple-watchface-example

like this.
```
code:error
 In file included from .pio/libdeps/esp32dev/WifiManager/WiFiManager.h:96,
                  from .pio/libdeps/esp32dev/Watchy/src/Watchy.h:5,
                  from src/Watchy_7_SEG.h:4,
                  from /Users/hiroshi/wc/hiroshi/watchy/my_new_watchy_face_project/src/7_SEG.ino:1:
 .pio/libdeps/esp32dev/WifiManager/strings_en.h:348:46: error: 'CONFIG_ESP32_PHY_MAX_TX_POWER' was not declared in this scope
  const wifi_country_t WM_COUNTRY_US{"US",1,11,CONFIG_ESP32_PHY_MAX_TX_POWER,WIFI_COUNTRY_POLICY_AUTO};
                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I found similar issue https://github.com/espressif/arduino-esp32/issues/5821.

New versions of WifiManager addressed this issue.
https://github.com/tzapu/WiFiManager/commit/72b53316105e6e15ec56b430b151907b4867e66a

So I changed pinned version of WifiManager to current latest version.

After this change I could compile and load the example on my watchy.
I'm not sure the example is working correctly though. The screen is refreshing every 5s. However I was getting started!!

Thanks.
